### PR TITLE
Timer0 CTC porting

### DIFF
--- a/AVR307/Makefile
+++ b/AVR307/Makefile
@@ -1,0 +1,226 @@
+# Hey Emacs, this is a -*- makefile -*-
+
+# AVR-GCC Makefile template, derived from the WinAVR template (which
+# is public domain), believed to be neutral to any flavor of "make"
+# (GNU make, BSD make, SysV make)
+
+
+MCU = attiny85
+FORMAT = ihex
+TARGET = AVR307
+SRC = main.c USI_UART.c
+ASRC = 
+OPT = s
+
+# Name of this Makefile (used for "make depend").
+MAKEFILE = Makefile
+
+# Debugging format.
+# Native formats for AVR-GCC's -g are stabs [default], or dwarf-2.
+# AVR (extended) COFF requires stabs, plus an avr-objcopy run.
+DEBUG = dwarf-2
+
+# Compiler flag to set the C Standard level.
+# c89   - "ANSI" C
+# gnu89 - c89 plus GCC extensions
+# c99   - ISO C99 standard (not yet fully implemented)
+# gnu99 - c99 plus GCC extensions
+CSTANDARD = -std=gnu99
+
+# Place -D or -U options here
+CDEFS = -DF_CPU=1000000ul
+
+# Place -I options here
+CINCS =
+
+
+CDEBUG = -g$(DEBUG)
+CWARN = -Wall -Wextra
+CTUNING = -funsigned-char -funsigned-bitfields -fpack-struct -fshort-enums
+#CEXTRA = -Wa,-adhlns=$(<:.c=.lst)
+CFLAGS = $(CDEBUG) $(CDEFS) $(CINCS) -O$(OPT) $(CWARN) $(CSTANDARD) $(CEXTRA)
+
+
+#ASFLAGS = -Wa,-adhlns=$(<:.S=.lst),-gstabs
+
+
+#Additional libraries.
+
+# Minimalistic printf version
+PRINTF_LIB_MIN = -Wl,-u,vfprintf -lprintf_min
+
+# Floating point printf version (requires MATH_LIB = -lm below)
+PRINTF_LIB_FLOAT = -Wl,-u,vfprintf -lprintf_flt
+
+PRINTF_LIB = 
+
+# Minimalistic scanf version
+SCANF_LIB_MIN = -Wl,-u,vfscanf -lscanf_min
+
+# Floating point + %[ scanf version (requires MATH_LIB = -lm below)
+SCANF_LIB_FLOAT = -Wl,-u,vfscanf -lscanf_flt
+
+SCANF_LIB = 
+
+MATH_LIB = -lm
+
+# External memory options
+
+# 64 KB of external RAM, starting after internal RAM (ATmega128!),
+# used for variables (.data/.bss) and heap (malloc()).
+#EXTMEMOPTS = -Wl,--section-start,.data=0x801100,--defsym=__heap_end=0x80ffff
+
+# 64 KB of external RAM, starting after internal RAM (ATmega128!),
+# only used for heap (malloc()).
+#EXTMEMOPTS = -Wl,--defsym=__heap_start=0x801100,--defsym=__heap_end=0x80ffff
+
+EXTMEMOPTS =
+
+#LDMAP = $(LDFLAGS) -Wl,-Map=$(TARGET).map,--cref
+LDFLAGS = $(EXTMEMOPTS) $(LDMAP) $(PRINTF_LIB) $(SCANF_LIB) $(MATH_LIB)
+
+
+# Programming support using avrdude. Settings and variables.
+
+AVRDUDE_PROGRAMMER = jtag2
+AVRDUDE_PORT = usb
+
+AVRDUDE_WRITE_FLASH = -U flash:w:$(TARGET).hex
+#AVRDUDE_WRITE_EEPROM = -U eeprom:w:$(TARGET).eep
+
+
+# Uncomment the following if you want avrdude's erase cycle counter.
+# Note that this counter needs to be initialized first using -Yn,
+# see avrdude manual.
+#AVRDUDE_ERASE_COUNTER = -y
+
+# Uncomment the following if you do /not/ wish a verification to be
+# performed after programming the device.
+#AVRDUDE_NO_VERIFY = -V
+
+# Increase verbosity level.  Please use this when submitting bug
+# reports about avrdude. See <http://savannah.nongnu.org/projects/avrdude> 
+# to submit bug reports.
+#AVRDUDE_VERBOSE = -v -v
+
+AVRDUDE_BASIC = -p $(MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER)
+AVRDUDE_FLAGS = $(AVRDUDE_BASIC) $(AVRDUDE_NO_VERIFY) $(AVRDUDE_VERBOSE) $(AVRDUDE_ERASE_COUNTER)
+
+
+CC = avr-gcc
+OBJCOPY = avr-objcopy
+OBJDUMP = avr-objdump
+SIZE = avr-size
+NM = avr-nm
+AVRDUDE = avrdude
+REMOVE = rm -f
+MV = mv -f
+
+# Define all object files.
+OBJ = $(SRC:.c=.o) $(ASRC:.S=.o) 
+
+# Define all listing files.
+LST = $(ASRC:.S=.lst) $(SRC:.c=.lst)
+
+# Combine all necessary flags and optional flags.
+# Add target processor to flags.
+ALL_CFLAGS = -mmcu=$(MCU) -I. $(CFLAGS)
+ALL_ASFLAGS = -mmcu=$(MCU) -I. -x assembler-with-cpp $(ASFLAGS)
+
+
+# Default target.
+all: build
+
+#build: elf hex eep
+build: elf hex
+
+elf: $(TARGET).elf
+hex: $(TARGET).hex
+eep: $(TARGET).eep
+lss: $(TARGET).lss 
+sym: $(TARGET).sym
+
+
+# Program the device.  
+program: $(TARGET).hex $(TARGET).eep
+	$(AVRDUDE) $(AVRDUDE_FLAGS) $(AVRDUDE_WRITE_FLASH) $(AVRDUDE_WRITE_EEPROM)
+
+
+
+
+# Convert ELF to COFF for use in debugging / simulating in AVR Studio or VMLAB.
+COFFCONVERT=$(OBJCOPY) --debugging \
+--change-section-address .data-0x800000 \
+--change-section-address .bss-0x800000 \
+--change-section-address .noinit-0x800000 \
+--change-section-address .eeprom-0x810000 
+
+
+coff: $(TARGET).elf
+	$(COFFCONVERT) -O coff-avr $(TARGET).elf $(TARGET).cof
+
+
+extcoff: $(TARGET).elf
+	$(COFFCONVERT) -O coff-ext-avr $(TARGET).elf $(TARGET).cof
+
+
+.SUFFIXES: .elf .hex .eep .lss .sym
+
+.elf.hex:
+	$(OBJCOPY) -O $(FORMAT) -R .eeprom $< $@
+
+.elf.eep:
+	-$(OBJCOPY) -j .eeprom --set-section-flags=.eeprom="alloc,load" \
+	--change-section-lma .eeprom=0 -O $(FORMAT) $< $@
+
+# Create extended listing file from ELF output file.
+.elf.lss:
+	$(OBJDUMP) -h -S $< > $@
+
+# Create a symbol table from ELF output file.
+.elf.sym:
+	$(NM) -n $< > $@
+
+
+
+# Link: create ELF output file from object files.
+$(TARGET).elf: $(OBJ)
+	$(CC) $(ALL_CFLAGS) $(OBJ) --output $@ $(LDFLAGS)
+
+
+# Compile: create object files from C source files.
+.c.o:
+	$(CC) -c $(ALL_CFLAGS) $< -o $@ 
+
+
+# Compile: create assembler files from C source files.
+.c.s:
+	$(CC) -S $(ALL_CFLAGS) $< -o $@
+
+
+# Assemble: create object files from assembler source files.
+.S.o:
+	$(CC) -c $(ALL_ASFLAGS) $< -o $@
+
+
+
+# Target: clean project.
+clean:
+	$(REMOVE) $(TARGET).hex $(TARGET).eep $(TARGET).cof $(TARGET).elf \
+	$(TARGET).map $(TARGET).sym $(TARGET).lss \
+	$(OBJ) $(LST) $(SRC:.c=.s) $(SRC:.c=.d)
+
+depend:
+	if grep '^# DO NOT DELETE' $(MAKEFILE) >/dev/null; \
+	then \
+		sed -e '/^# DO NOT DELETE/,$$d' $(MAKEFILE) > \
+			$(MAKEFILE).$$$$ && \
+		$(MV) $(MAKEFILE).$$$$ $(MAKEFILE); \
+	fi
+	echo '# DO NOT DELETE THIS LINE -- make depend depends on it.' \
+		>> $(MAKEFILE); \
+	$(CC) -M -mmcu=$(MCU) $(CDEFS) $(CINCS) $(SRC) $(ASRC) >> $(MAKEFILE)
+
+.PHONY:	all build elf hex eep lss sym program coff extcoff clean depend
+
+

--- a/AVR307/USI_UART.c
+++ b/AVR307/USI_UART.c
@@ -13,16 +13,9 @@
 
 #define USI_COUNTER_MAX_COUNT     16
 #define USI_COUNTER_SEED_TRANSMIT (USI_COUNTER_MAX_COUNT - HALF_FRAME)
-#define INTERRUPT_STARTUP_DELAY   (0x11 / TIMER_PRESCALER)
-#define TIMER0_SEED               (256 - ( (SYSTEM_CLOCK / BAUDRATE) / TIMER_PRESCALER ))
+#define TIMER0_TOP                (( (SYSTEM_CLOCK / BAUDRATE) / TIMER_PRESCALER ) - 1)
 
-#if ( (( (SYSTEM_CLOCK / BAUDRATE) / TIMER_PRESCALER ) * 3/2) > (256 - INTERRUPT_STARTUP_DELAY) )
-    #define INITIAL_TIMER0_SEED       ( 256 - (( (SYSTEM_CLOCK / BAUDRATE) / TIMER_PRESCALER ) * 1/2) )
-    #define USI_COUNTER_SEED_RECEIVE  ( USI_COUNTER_MAX_COUNT - (START_BIT + DATA_BITS) )
-#else
-    #define INITIAL_TIMER0_SEED       ( 256 - (( (SYSTEM_CLOCK / BAUDRATE) / TIMER_PRESCALER ) * 3/2) )
-    #define USI_COUNTER_SEED_RECEIVE  (USI_COUNTER_MAX_COUNT - DATA_BITS)
-#endif
+#define USI_COUNTER_SEED_RECEIVE  ( USI_COUNTER_MAX_COUNT - (START_BIT + DATA_BITS) )
 
 #define UART_RX_BUFFER_MASK ( UART_RX_BUFFER_SIZE - 1 )
 #if ( UART_RX_BUFFER_SIZE & UART_RX_BUFFER_MASK )
@@ -93,9 +86,9 @@ void USI_UART_Initialise_Transmitter( void )
     cli();
     TCNT0  = 0x00;
     GTCCR  = (1<<PSR0);                                       // Reset the prescaler and start Timer0.
+    TCCR0A = (1<<WGM01);                                      // ... in CTC mode
+    OCR0A  = TIMER0_TOP;
     TCCR0B = (0<<CS02)|(0<<CS01)|(1<<CS00);
-    TIFR   = (1<<TOV0);                                       // Clear Timer0 OVF interrupt flag.
-    TIMSK |= (1<<TOIE0);                                      // Enable Timer0 OVF interrupt.
                                                                 
     USICR  = (0<<USISIE)|(1<<USIOIE)|                         // Enable USI Counter OVF interrupt.
              (0<<USIWM1)|(1<<USIWM0)|                         // Select Three Wire mode.
@@ -169,11 +162,11 @@ ISR(PCINT0_vect)
 {                                                                    
     if (!( PINB & (1<<PB0) ))                                     // If the USI DI pin is low, then it is likely that it
     {                                                             //  was this pin that generated the pin change interrupt.
-        TCNT0  = INTERRUPT_STARTUP_DELAY + INITIAL_TIMER0_SEED;   // Plant TIMER0 seed to match baudrate (incl interrupt start up time.).
+        TCNT0  = TIMER0_TOP / 2;                                  // Plant TIMER0 seed to match baudrate.
         GTCCR  = (1<<PSR0);                                       // Reset the prescaler and start Timer0.
+        TCCR0A = (1<<WGM01);                                      // ... in CTC mode
+        OCR0A  = TIMER0_TOP;
         TCCR0B = (0<<CS02)|(0<<CS01)|(1<<CS00);
-        TIFR   = (1<<TOV0);                                       // Clear Timer0 OVF interrupt flag.
-        TIMSK |= (1<<TOIE0);                                      // Enable Timer0 OVF interrupt.
                                                                     
         USICR  = (0<<USISIE)|(1<<USIOIE)|                         // Enable USI Counter OVF interrupt.
                  (0<<USIWM1)|(1<<USIWM0)|                         // Select Three Wire mode.
@@ -264,12 +257,5 @@ ISR(USI_OVF_vect)
         GIMSK |=  (1<<PCIE);                                    // Enable pin change interrupt for PB0.
     }
     
-}
-
-// Timer0 Overflow interrupt is used to trigger the sampling of signals on the USI ports.
-ISR(TIM0_OVF_vect)
-{
-    TCNT0 += TIMER0_SEED;                   // Reload the timer,
-                                            // current count is added for timing correction.
 }
 

--- a/AVR307/USI_UART.c
+++ b/AVR307/USI_UART.c
@@ -92,7 +92,8 @@ void USI_UART_Initialise_Transmitter( void )
 {
     cli();
     TCNT0  = 0x00;
-    TCCR0  = (1<<PSR0)|(0<<CS02)|(0<<CS01)|(1<<CS00);         // Reset the prescaler and start Timer0.
+    GTCCR  = (1<<PSR0);                                       // Reset the prescaler and start Timer0.
+    TCCR0B = (0<<CS02)|(0<<CS01)|(1<<CS00);
     TIFR   = (1<<TOV0);                                       // Clear Timer0 OVF interrupt flag.
     TIMSK |= (1<<TOIE0);                                      // Enable Timer0 OVF interrupt.
                                                                 
@@ -120,7 +121,7 @@ void USI_UART_Initialise_Receiver( void )
     DDRB  &= ~((1<<PB3)|(1<<PB2)|(1<<PB1)|(1<<PB0));        // Set USI DI, DO and SCK pins as inputs.  
     USICR  =  0;                                            // Disable USI.
     GIFR   =  (1<<PCIF);                                    // Clear pin change interrupt flag.
-    GIMSK |=  (1<<PCIE0);                                   // Enable pin change interrupt for PB3:0.
+    GIMSK |=  (1<<PCIE);                                    // Enable pin change interrupt for PB3:0.
 }
 
 // Puts data in the transmission buffer, after reverseing the bits in the byte.
@@ -168,7 +169,8 @@ ISR(PCINT0_vect)
     if (!( PINB & (1<<PB0) ))                                     // If the USI DI pin is low, then it is likely that it
     {                                                             //  was this pin that generated the pin change interrupt.
         TCNT0  = INTERRUPT_STARTUP_DELAY + INITIAL_TIMER0_SEED;   // Plant TIMER0 seed to match baudrate (incl interrupt start up time.).
-        TCCR0  = (1<<PSR0)|(0<<CS02)|(0<<CS01)|(1<<CS00);         // Reset the prescaler and start Timer0.
+        GTCCR  = (1<<PSR0);                                       // Reset the prescaler and start Timer0.
+        TCCR0B = (0<<CS02)|(0<<CS01)|(1<<CS00);
         TIFR   = (1<<TOV0);                                       // Clear Timer0 OVF interrupt flag.
         TIMSK |= (1<<TOIE0);                                      // Enable Timer0 OVF interrupt.
                                                                     
@@ -180,7 +182,7 @@ ISR(PCINT0_vect)
         USISR  = 0xF0 |                                           // Clear all USI interrupt flags.
                  USI_COUNTER_SEED_RECEIVE;                        // Preload the USI counter to generate interrupt.
                                                                   
-        GIMSK &=  ~(1<<PCIE0);                                    // Disable pin change interrupt for PB3:0. 
+        GIMSK &=  ~(1<<PCIE);                                     // Disable pin change interrupt for PB3:0. 
         
         USI_UART_status.ongoing_Reception_Of_Package = TRUE;             
     }
@@ -224,12 +226,12 @@ ISR(USI_OVF_vect)
             {
                 USI_UART_status.ongoing_Transmission_From_Buffer = FALSE; 
                 
-                TCCR0  = (0<<CS02)|(0<<CS01)|(0<<CS00);                 // Stop Timer0.
+                TCCR0B  = (0<<CS02)|(0<<CS01)|(0<<CS00);                // Stop Timer0.
                 PORTB |=   (1<<PB3)|(1<<PB2)|(1<<PB1)|(1<<PB0);         // Enable pull up on USI DO, DI and SCK pins. (And PB3 because of pin change interrupt)   
                 DDRB  &= ~((1<<PB3)|(1<<PB2)|(1<<PB1)|(1<<PB0));        // Set USI DI, DO and SCK pins as inputs.  
                 USICR  =  0;                                            // Disable USI.
                 GIFR   =  (1<<PCIF);                                    // Clear pin change interrupt flag.
-                GIMSK |=  (1<<PCIE0);                                   // Enable pin change interrupt for PB3:0.
+                GIMSK |=  (1<<PCIE);                                    // Enable pin change interrupt for PB3:0.
             }
         }
     }
@@ -251,12 +253,12 @@ ISR(USI_OVF_vect)
             UART_RxBuf[tmphead] = USIDR;                                // Store received data in buffer. Note that the data must be bit reversed before used. 
         }                                                               // The bit reversing is moved to the application section to save time within the interrupt.
                                                                 
-        TCCR0  = (0<<CS02)|(0<<CS01)|(0<<CS00);                 // Stop Timer0.
+        TCCR0B  = (0<<CS02)|(0<<CS01)|(0<<CS00);                // Stop Timer0.
         PORTB |=   (1<<PB3)|(1<<PB2)|(1<<PB1)|(1<<PB0);         // Enable pull up on USI DO, DI and SCK pins. (And PB3 because of pin change interrupt)   
         DDRB  &= ~((1<<PB3)|(1<<PB2)|(1<<PB1)|(1<<PB0));        // Set USI DI, DO and SCK pins as inputs.  
         USICR  =  0;                                            // Disable USI.
         GIFR   =  (1<<PCIF);                                    // Clear pin change interrupt flag.
-        GIMSK |=  (1<<PCIE0);                                   // Enable pin change interrupt for PB3:0.
+        GIMSK |=  (1<<PCIE);                                    // Enable pin change interrupt for PB3:0.
     }
     
 }

--- a/AVR307/USI_UART.c
+++ b/AVR307/USI_UART.c
@@ -121,7 +121,8 @@ void USI_UART_Initialise_Receiver( void )
     DDRB  &= ~((1<<PB3)|(1<<PB2)|(1<<PB1)|(1<<PB0));        // Set USI DI, DO and SCK pins as inputs.  
     USICR  =  0;                                            // Disable USI.
     GIFR   =  (1<<PCIF);                                    // Clear pin change interrupt flag.
-    GIMSK |=  (1<<PCIE);                                    // Enable pin change interrupt for PB3:0.
+    PCMSK = (1<<PCINT0);
+    GIMSK |=  (1<<PCIE);                                    // Enable pin change interrupt for PB0.
 }
 
 // Puts data in the transmission buffer, after reverseing the bits in the byte.
@@ -231,7 +232,8 @@ ISR(USI_OVF_vect)
                 DDRB  &= ~((1<<PB3)|(1<<PB2)|(1<<PB1)|(1<<PB0));        // Set USI DI, DO and SCK pins as inputs.  
                 USICR  =  0;                                            // Disable USI.
                 GIFR   =  (1<<PCIF);                                    // Clear pin change interrupt flag.
-                GIMSK |=  (1<<PCIE);                                    // Enable pin change interrupt for PB3:0.
+                PCMSK = (1<<PCINT0);
+                GIMSK |=  (1<<PCIE);                                    // Enable pin change interrupt for PB0.
             }
         }
     }
@@ -258,7 +260,8 @@ ISR(USI_OVF_vect)
         DDRB  &= ~((1<<PB3)|(1<<PB2)|(1<<PB1)|(1<<PB0));        // Set USI DI, DO and SCK pins as inputs.  
         USICR  =  0;                                            // Disable USI.
         GIFR   =  (1<<PCIF);                                    // Clear pin change interrupt flag.
-        GIMSK |=  (1<<PCIE);                                    // Enable pin change interrupt for PB3:0.
+        PCMSK = (1<<PCINT0);
+        GIMSK |=  (1<<PCIE);                                    // Enable pin change interrupt for PB0.
     }
     
 }

--- a/AVR307/USI_UART_config.h
+++ b/AVR307/USI_UART_config.h
@@ -1,13 +1,6 @@
 //********** USI UART Defines **********//
 
-//#define SYSTEM_CLOCK             14745600
-//#define SYSTEM_CLOCK             11059200
-//#define SYSTEM_CLOCK              8000000
-//#define SYSTEM_CLOCK              7372800
-#define SYSTEM_CLOCK              3686400
-//#define SYSTEM_CLOCK              2000000
-//#define SYSTEM_CLOCK              1843200
-//#define SYSTEM_CLOCK              1000000
+#define SYSTEM_CLOCK              F_CPU
 
 //#define BAUDRATE                   115200
 //#define BAUDRATE                    57600

--- a/AVR307/main.c
+++ b/AVR307/main.c
@@ -1,5 +1,6 @@
 #include <avr/io.h>
 #include <avr/interrupt.h>
+#include <avr/sleep.h>
 
 #include "USI_UART_config.h"
 
@@ -12,7 +13,7 @@ int main( void )
 	
 	USI_UART_Flush_Buffers();
 	USI_UART_Initialise_Receiver();                                         // Initialisation for USI_UART receiver
-	__enable_interrupt();                                                   // Enable global interrupts
+	sei();                                                                  // Enable global interrupts
 	
 	MCUCR = (1<<SE)|(0<<SM1)|(0<<SM0);                                      // Enable Sleepmode: Idle
 	
@@ -26,6 +27,6 @@ int main( void )
 			}
 			USI_UART_Transmit_Byte( USI_UART_Receive_Byte() );              // Echo the received character
 		}
-		__sleep();                                                          // Sleep when waiting for next event
+		sleep_cpu();                                                            // Sleep when waiting for next event
 	}
 }


### PR DESCRIPTION
The original AVR307 code had been written for the ATtiny26 where there was no CTC option in its timer 0.

ATtiny85 (and other modern AVRs) have CTC, making generation of arbitrary frequencies much easier. Adapt the code for that.